### PR TITLE
Added bbox option for home button

### DIFF
--- a/src/Leaflet.NavBar.js
+++ b/src/Leaflet.NavBar.js
@@ -8,6 +8,7 @@
       position: 'topleft',
       //center:,
       //zoom :,
+      //bbox:, //Alternative to center/zoom for home button, takes precedence if included
       forwardTitle: 'Go forward in map view history',
       backTitle: 'Go back in map view history',
       homeTitle: 'Go to home map view'
@@ -49,6 +50,13 @@
     },
 
     _goHome: function() {
+      if (this.options.bbox){
+        try {
+          this._map.fitBounds(this.options.bbox);
+        } catch(err){
+          this._map.setView(this.options.center, this.options.zoom); //Use default if invalid bbox input.
+        }
+      }
       this._map.setView(this.options.center, this.options.zoom);
     },
 


### PR DESCRIPTION
If user enters a valid bbox, the home button will use map.fitBounds(bbox) instead of map.setView(center,zoom). Will take precedence over center/zoom if both are input.
